### PR TITLE
fix: remove unused date formatting for tripDate in export payload

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voy",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "App created to manage Rosaprima's farms trips.",
   "main": "./out/main/index.js",
   "author": "gomiiDev & devdiagon",

--- a/src/renderer/src/utils/export/tripExportMapper.ts
+++ b/src/renderer/src/utils/export/tripExportMapper.ts
@@ -1,5 +1,5 @@
 import { ExportTripWorkSheet, ExportWorkZoneSheet } from '@renderer/types';
-import { calcTimeDifference, formatDate, formatDateNoYear, formatShortDate } from '../dateUtils';
+import { calcTimeDifference, formatDate, formatDateNoYear } from '../dateUtils';
 
 // From ExportWorkZoneSheet[] (backend) ------> ExportTripWorkSheet (frontend export use) with formatted date
 export const buildExportPayload = (data: ExportWorkZoneSheet[]): ExportTripWorkSheet[] => {
@@ -12,7 +12,7 @@ export const buildExportPayload = (data: ExportWorkZoneSheet[]): ExportTripWorkS
       workSheetName: sheet.workSheet.name
     },
     rows: sheet.trips.map((trip) => ({
-      tripDate: formatShortDate(trip.tripDate),
+      tripDate: trip.tripDate,
       departureTime: trip.departureTime,
       arrivalTime: trip.arrivalTime,
       waitingTime: calcTimeDifference(trip.arrivalTime, trip.departureTime),


### PR DESCRIPTION
This pull request makes a small update to the `buildExportPayload` function in `tripExportMapper.ts`. The change removes the use of the `formatShortDate` function for the `tripDate` field, now passing the raw `tripDate` value instead. Additionally, the unused `formatShortDate` import was removed.